### PR TITLE
Documentation fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,7 @@ small, atomic pieces to make reviews easier.
 
 Please make sure that the source code formatting follows the guidelines at
 https://community.openvpn.net/openvpn/wiki/CodeStyle. Automated checking can be
-done with uncrustify (http://uncrustify.sourceforge.net/) and the configuration
+done with uncrustify (https://uncrustify.sourceforge.net/) and the configuration
 file which can be found in the git repository at dev-tools/uncrustify.conf.
 There is also a git pre-commit hook script, which runs uncrustify automatically
 each time you commit and lets you format your code conveniently, if needed.

--- a/INSTALL
+++ b/INSTALL
@@ -67,7 +67,7 @@ SYSTEM REQUIREMENTS:
       a virtual point-to-point IP or Ethernet device.
       See TUN/TAP Driver References section below for more info.
   (2a) OpenSSL library, necessary for encryption, version 1.1.0 or higher
-      required, available from http://www.openssl.org/
+      required, available from https://www.openssl.org/
       or
   (2b) mbed TLS library, an alternative for encryption, version 2.0 or higher
       required, available from https://tls.mbed.org/
@@ -76,7 +76,7 @@ SYSTEM REQUIREMENTS:
 
 OPTIONAL:
   (5) LZO real-time compression library, required for link compression,
-      available from http://www.oberhumer.com/opensource/lzo/
+      available from https://www.oberhumer.com/opensource/lzo/
       (most supported operating systems have LZO in their installable
       packages repository.  It might be necessary to add LZO_CFLAGS=
       and LZO_LIBS= to the configure call to make it find the LZO pieces)
@@ -87,7 +87,7 @@ OPTIONAL (for developers only):
       Automake 1.9 or higher
       Libtool
       Git
-  (2) cmocka test framework (http://cmocka.org)
+  (2) cmocka test framework (https://cmocka.org)
   (3) If using t_client.sh test framework, fping/fping6 is needed
       Note: t_client.sh needs an external configured OpenVPN server.
       See t_client.rc-sample for more info.
@@ -261,7 +261,7 @@ TUN/TAP Driver References:
 
   You need a TUN/TAP kernel driver for OpenVPN to work:
 
-    http://www.whiteboard.ne.jp/~admin2/tuntap/
+    https://web.archive.org/web/20250504214754/http://www.whiteboard.ne.jp/~admin2/tuntap/
 
 * Haiku:
 

--- a/PORTS
+++ b/PORTS
@@ -41,7 +41,7 @@ PORTING GUIDELINE TO A NEW PLATFORM:
     platform.
   * Make sure that a tun or tap virtual device
     driver exists for your platform.  See
-    http://vtun.sourceforge.net/tun/ for examples
+    https://vtun.sourceforge.net/tun/ for examples
     of tun and tap drivers that have been written
     for Linux, Solaris, and FreeBSD.
   * Make sure you have autoconf 2.50+ and

--- a/README
+++ b/README
@@ -34,9 +34,6 @@ For a sample VPN configuration, see
 
 To report an issue, see
   https://github.com/OpenVPN/openvpn/issues/new
-  (Note: We recently switched to GitHub for reporting new issues,
-   old issues can be found at:
-   https://community.openvpn.net/openvpn/report)
 
 For a description of OpenVPN's underlying protocol,
   see the file ssl.h included in the source distribution.

--- a/dev-tools/git-pre-commit-format.sh
+++ b/dev-tools/git-pre-commit-format.sh
@@ -34,7 +34,7 @@
 #  - use clang-format or uncrustify depending on presence of .clang-format
 #    config file
 #
-# More info on Uncrustify: http://uncrustify.sourceforge.net/
+# More info on Uncrustify: https://uncrustify.sourceforge.net/
 
 # This file was taken from a set of unofficial pre-commit hooks available
 # at https://github.com/ddddavidmartin/Pre-commit-hooks and modified to

--- a/doc/android.txt
+++ b/doc/android.txt
@@ -7,7 +7,7 @@ This support is primarily used in the "OpenVPN for Android" app
 README: https://github.com/schwabe/ics-openvpn/blob/master/doc/README.txt
 
 Android provides the VPNService API
-(http://developer.android.com/reference/android/net/VpnService.html)
+(https://developer.android.com/reference/android/net/VpnService)
 which allows establishing VPN connections without rooting the device.
 
 Unlike on other platforms, the tun device is openend by UI instead of

--- a/doc/doxygen/doc_compression.h
+++ b/doc/doxygen/doc_compression.h
@@ -87,5 +87,5 @@
  *
  * @par
  * For more information on the LZO library, see:\n
- * http://www.oberhumer.com/opensource/lzo/
+ * https://www.oberhumer.com/opensource/lzo/
  */

--- a/doc/doxygen/doc_mainpage.h
+++ b/doc/doxygen/doc_mainpage.h
@@ -32,7 +32,7 @@
  * This documentation describes the internal structure of OpenVPN.  It was
  * automatically generated from specially formatted comment blocks in
  * OpenVPN's source code using Doxygen.  (See
- * http://www.stack.nl/~dimitri/doxygen/ for more information on Doxygen)
+ * https://www.doxygen.nl/ for more information on Doxygen)
  *
  * The \ref mainpage_modules "Modules section" below gives an introduction
  * into the high-level module concepts used throughout this documentation.

--- a/doc/keying-material-exporter.txt
+++ b/doc/keying-material-exporter.txt
@@ -117,21 +117,21 @@ Reference
 
    [RFC5705]               "Keying Material Exporters for TLS"
                            E. Rescorla, RFC 5705 March 2010
-                           http://tools.ietf.org/html/rfc5705
+                           https://tools.ietf.org/html/rfc5705
 
    [RFC5929]               "Channel Bindings for TLS"
                            J. Altman, N. Williams, L. Zhu, RFC 5929, July 2010
-                           http://tools.ietf.org/html/rfc5929
+                           https://tools.ietf.org/html/rfc5929
 
    [RFC4680]               "TLS Handshake Message for Supplemental Data"
                            S. Santesson, RFC 4680, September 2006
-                           http://tools.ietf.org/html/rfc4680
+                           https://tools.ietf.org/html/rfc4680
 
    [RFC5878]               "TLS Authorization Extension"
                            M. Brown, R. Housley, RFC 5878, May 2010
-                           http://tools.ietf.org/html/rfc5878
+                           https://tools.ietf.org/html/rfc5878
 
    [RFC5746]               "TLS Renegotiation Indication Extension"
                            E. Rescorla, M. Raym, S. Dispensa, N. Oskov
                            RFC 5746, February 2010
-                           http://tools.ietf.org/html/rfc5746
+                           https://tools.ietf.org/html/rfc5746

--- a/doc/man-sections/link-options.rst
+++ b/doc/man-sections/link-options.rst
@@ -338,7 +338,7 @@ the local and the remote host.
   used over unreliable or congested networks.
 
   This article outlines some of problems with tunneling IP over TCP:
-  http://sites.inka.de/sites/bigred/devel/tcp-tcp.html
+  https://web.archive.org/web/20141025181658/http://sites.inka.de/sites/bigred/devel/tcp-tcp.html
 
   There are certain cases, however, where using TCP may be advantageous
   from a security and robustness perspective, such as tunneling non-IP or

--- a/doc/man-sections/protocol-options.rst
+++ b/doc/man-sections/protocol-options.rst
@@ -52,7 +52,7 @@ configured in a compatible way between both the local and remote side.
   authentication.
 
   For more information on HMAC see
-  http://www.cs.ucsd.edu/users/mihir/papers/hmac.html
+  https://tools.ietf.org/html/rfc2104
 
 --cipher alg
   This option should not be used any longer in TLS mode and still

--- a/doc/openvpn.8.rst
+++ b/doc/openvpn.8.rst
@@ -150,10 +150,10 @@ NOTES
 This product includes software developed by the OpenSSL Project
 (https://www.openssl.org/)
 
-For more information on the TLS protocol, see
-http://www.ietf.org/rfc/rfc2246.txt
+For more information on the TLS protocol see:
+https://tools.ietf.org/html/rfc2246
 
-For more information on the LZO real-time compression library see
+For more information on the LZO real-time compression library see:
 https://www.oberhumer.com/opensource/lzo/
 
 

--- a/m4/pkg.m4
+++ b/m4/pkg.m4
@@ -181,7 +181,7 @@ path to pkg-config.
 
 _PKG_TEXT
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.])[]dnl
+To get pkg-config, see <https://www.freedesktop.org/wiki/Software/pkg-config/>.])[]dnl
         ])
 else
 	$1[]_CFLAGS=$pkg_cv_[]$1[]_CFLAGS

--- a/src/openvpn/list.c
+++ b/src/openvpn/list.c
@@ -338,7 +338,7 @@ hash_iterator_delete_element(struct hash_iterator *hi)
  * By Bob Jenkins, 1996.  bob_jenkins@burtleburtle.net.  You may use this
  * code any way you wish, private, educational, or commercial.  It's free.
  *
- * See http://burlteburtle.net/bob/hash/evahash.html
+ * See https://burtleburtle.net/bob/hash/evahash.html
  * Use for hash table lookup, or anything where one collision in 2^32 is
  * acceptable.  Do NOT use for cryptographic purposes.
  *

--- a/src/openvpn/memdbg.h
+++ b/src/openvpn/memdbg.h
@@ -62,7 +62,7 @@
  *
  * The dmalloc package can be downloaded from:
  *
- *     http://dmalloc.com/
+ *     https://dmalloc.com/
  *
  * When dmalloc is installed and enabled,
  * use this command prior to running openvpn:

--- a/src/openvpn/ntlm.c
+++ b/src/openvpn/ntlm.c
@@ -179,7 +179,7 @@ ntlm_phase_1(const struct http_proxy_info *p, struct gc_arena *gc)
     struct buffer out = alloc_buf_gc(96, gc);
     /* try a minimal NTLM handshake
      *
-     * http://davenport.sourceforge.net/ntlm.html
+     * https://davenport.sourceforge.net/ntlm.html
      *
      * This message contains only the NTLMSSP signature,
      * the NTLM message type,
@@ -195,7 +195,7 @@ ntlm_phase_3(const struct http_proxy_info *p, const char *phase_2, struct gc_are
 {
     /* NTLM handshake
      *
-     * http://davenport.sourceforge.net/ntlm.html
+     * https://davenport.sourceforge.net/ntlm.html
      *
      */
 

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -23,7 +23,7 @@
 
 /*
  * 2004-01-28: Added Socks5 proxy support
- *   (Christof Meerwald, http://cmeerw.org)
+ *   (Christof Meerwald, https://cmeerw.org)
  */
 
 #ifdef HAVE_CONFIG_H

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -22,7 +22,7 @@
 
 /*
  * 2004-01-28: Added Socks5 proxy support
- *   (Christof Meerwald, http://cmeerw.org)
+ *   (Christof Meerwald, https://cmeerw.org)
  */
 
 #ifndef OPTIONS_H

--- a/src/openvpn/route.c
+++ b/src/openvpn/route.c
@@ -3259,9 +3259,9 @@ done:
 }
 
 /* IPv6 implementation using netlink
- * http://www.linuxjournal.com/article/7356
+ * https://www.linuxjournal.com/article/7356 - "Kernel Korner - Why and How to Use Netlink Socket"
  * netlink(3), netlink(7), rtnetlink(7)
- * http://www.virtualbox.org/svn/vbox/trunk/src/VBox/NetworkServices/NAT/rtmon_linux.c
+ * https://www.virtualbox.org/svn/vbox/trunk/src/VBox/NetworkServices/NAT/
  */
 struct rtreq
 {

--- a/src/openvpn/socks.c
+++ b/src/openvpn/socks.c
@@ -22,7 +22,7 @@
 
 /*
  * 2004-01-30: Added Socks5 proxy support, see RFC 1928
- *   (Christof Meerwald, http://cmeerw.org)
+ *   (Christof Meerwald, https://cmeerw.org)
  *
  * 2010-10-10: Added Socks5 plain text authentication support (RFC 1929)
  *   (Pierre Bourdon <delroth@gmail.com>)

--- a/src/openvpn/socks.h
+++ b/src/openvpn/socks.h
@@ -22,7 +22,7 @@
 
 /*
  * 2004-01-30: Added Socks5 proxy support
- *   (Christof Meerwald, http://cmeerw.org)
+ *   (Christof Meerwald, https://cmeerw.org)
  */
 
 #ifndef SOCKS_H

--- a/src/openvpn/tun.c
+++ b/src/openvpn/tun.c
@@ -2294,7 +2294,7 @@ open_tun(const char *dev, const char *dev_type, const char *dev_node, struct tun
     struct strioctl strioc_if, strioc_ppa;
 
     /* improved generic TUN/TAP driver from
-     * http://www.whiteboard.ne.jp/~admin2/tuntap/
+     * https://web.archive.org/web/20250504214754/http://www.whiteboard.ne.jp/~admin2/tuntap/
      * has IPv6 support
      */
     CLEAR(ifr);
@@ -3125,7 +3125,7 @@ read_tun(struct tuntap *tt, uint8_t *buf, int len)
 /*
  * utun is the native Darwin tun driver present since at least 10.7
  * Thanks goes to Jonathan Levin for providing an example how to utun
- * (http://newosxbook.com/src.jl?tree=listings&file=17-15-utun.c)
+ * (https://www.cs.dartmouth.edu/~sergey/netreads/utun/utun-demo.c)
  */
 
 /* Helper functions that tries to open utun device

--- a/src/openvpn/win32-util.c
+++ b/src/openvpn/win32-util.c
@@ -68,8 +68,7 @@ utf16to8(const wchar_t *utf16, struct gc_arena *gc)
  * CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
  * LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9, and CLOCK$
  *
- * See: http://msdn.microsoft.com/en-us/library/aa365247.aspx
- *  and http://msdn.microsoft.com/en-us/library/86k9f82k(VS.80).aspx
+ * See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
  */
 
 static bool


### PR DESCRIPTION

This started with fixing the three stale URLs in openvpn(8) but
got slightly out of hand and the 2nd commit contains some URL
fixes throughout the whole tree.
